### PR TITLE
Add AI Rename Capability and Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,4 +287,7 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Project specific files
+/RenameEpisodeFiles/secrets.json
 /Scripts/TestFiles

--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,4 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+/Scripts/TestFiles

--- a/RenameEpisodeFiles/FileRenamer.cs
+++ b/RenameEpisodeFiles/FileRenamer.cs
@@ -48,7 +48,7 @@ namespace RenameEpisodeFiles
             return lastEpisode;
         }
 
-        public static async void RenameEpisodesWithAI(string folderPath, string showName)
+        public static async Task RenameEpisodesWithAI(string folderPath, string showName)
         {
             // Get all files in the directory
             var files = new DirectoryInfo(folderPath)

--- a/RenameEpisodeFiles/FileRenamer.cs
+++ b/RenameEpisodeFiles/FileRenamer.cs
@@ -67,13 +67,13 @@ namespace RenameEpisodeFiles
             var response = await openAIService.Chat.Get($"""
                 The following list of filenames are in the format of <Show Title><Separator><Season><Episodes><Separator><Optional Title>.<Extension>. 
                 I want them to be in the format \"{showName}.S<Season Number>E<Episode Number>.<Title>.<Extension>. 
-                Get the <Title> from theTVDB, using the {showName} DVD Order tab for that <Season Number>.\r\n{fileNamesString}\r\n
+                Get the <Title> from theTVDB, using the {showName} tab for that <Season Number>.\r\n{fileNamesString}\r\n
                 Return back only the list of updated filenames without any response text. 
                 Do not include bullets or number prefixes.
                 """, (options) =>
             {
                 options.Model = "gpt-4.1";
-                options.MaxTokens = 2000;
+                options.MaxTokens = 4000;
                 options.Temperature = 0.7;
             });
 

--- a/RenameEpisodeFiles/FileRenamer.cs
+++ b/RenameEpisodeFiles/FileRenamer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using OpenAI.Net;
 
 namespace RenameEpisodeFiles
 {
@@ -43,6 +44,30 @@ namespace RenameEpisodeFiles
             }
 
             return lastEpisode;
+        }
+
+        public static async void RenameEpisodesWithAI(string folderPath, string showName)
+        {
+            // Get all files in the directory
+            var files = new DirectoryInfo(folderPath)
+                .GetFiles()
+                .OrderBy(f => f.CreationTime)
+                .ToList();
+
+            // Convert to a list of file names as newline -separated strings
+            var fileNames = files.Select(f => f.Name).ToList();
+
+            // Convert the list to a single string with each filename on a new line
+            string fileNamesString = string.Join(Environment.NewLine, fileNames);
+
+            // Make an API call to OpenAI to get the episode names using the OpenAI.Net.Client library
+            var openAIService = Program.OpenAIService;
+            var response = await openAIService.Chat.Get($"Extract episode names from the following file names:\n{fileNamesString}\n\nPlease provide the episode names in the format 'SxxExx - Episode Name'.", (options) =>
+            {
+                options.Model = "gpt-3.5-turbo";
+                options.MaxTokens = 1000;
+                options.Temperature = 0.7;
+            });
         }
 
 

--- a/RenameEpisodeFiles/FileRenamer.cs
+++ b/RenameEpisodeFiles/FileRenamer.cs
@@ -75,6 +75,23 @@ namespace RenameEpisodeFiles
             {
                 var aiResponseText = response.Result!.Choices[0].Message.Content;
                 Program.Logger.LogDebug($"AI Response: {aiResponseText}");
+                // Split the response into an array of lines
+                var newFileNames = aiResponseText.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(line => line.Trim())
+                    .ToList();
+                // Rename files based on AI response
+                for (int i = 0; i < files.Count && i < newFileNames.Count; i++)
+                {
+                    var file = files[i];
+                    string newFileName = newFileNames[i];
+                    string newFilePath = Path.Combine(folderPath, newFileName);
+                    // Check if the new file name is different before renaming
+                    if (!string.Equals(file.FullName, newFilePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        File.Move(file.FullName, newFilePath);
+                        Program.Logger.LogInformation($"Renamed '{file.Name}' to '{newFileName}'");
+                    }
+                }
             }
             else
             {

--- a/RenameEpisodeFiles/FileRenamer.cs
+++ b/RenameEpisodeFiles/FileRenamer.cs
@@ -67,12 +67,12 @@ namespace RenameEpisodeFiles
             var response = await openAIService.Chat.Get($"""
                 The following list of filenames are in the format of <Show Title><Separator><Season><Episodes><Separator><Optional Title>.<Extension>. 
                 I want them to be in the format \"{showName}.S<Season Number>E<Episode Number>.<Title>.<Extension>. 
-                If the Title isn't in the filename, grab it from theTVDB, using the {showName} DVD Order tab for that <Season Number>.\r\n{fileNamesString}\r\n
-                Return back only the list of updated filenames without any other text. 
+                Get the <Title> from theTVDB, using the {showName} DVD Order tab for that <Season Number>.\r\n{fileNamesString}\r\n
+                Return back only the list of updated filenames without any response text. 
                 Do not include bullets or number prefixes.
                 """, (options) =>
             {
-                options.Model = "gpt-3.5-turbo";
+                options.Model = "gpt-4.1";
                 options.MaxTokens = 2000;
                 options.Temperature = 0.7;
             });
@@ -103,7 +103,16 @@ namespace RenameEpisodeFiles
                     // Check if the new file name is different before renaming
                     if (FileDoesNotExist(file.FullName, newFilePath))
                     {
+                        Program.Logger.LogInformation($"Renaming '{file.FullName}' to '{newFileName}'");
+                        try
+                        {
                         File.Move(file.FullName, newFilePath);
+                        }
+                        catch (Exception ex)
+                        {
+                            Program.Logger.LogError(new EventId(), ex, ex.Message);
+                            continue;
+                        }
                         Program.Logger.LogInformation($"Renamed '{file.FullName}' to '{newFileName}'");
                     }
                     else

--- a/RenameEpisodeFiles/FileRenamer.cs
+++ b/RenameEpisodeFiles/FileRenamer.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using OpenAI.Net;
+using OpenAI.Net.Models.Responses;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using OpenAI.Net;
 
 namespace RenameEpisodeFiles
 {
@@ -62,12 +64,24 @@ namespace RenameEpisodeFiles
 
             // Make an API call to OpenAI to get the episode names using the OpenAI.Net.Client library
             var openAIService = Program.OpenAIService;
-            var response = await openAIService.Chat.Get($"Extract episode names from the following file names:\n{fileNamesString}\n\nPlease provide the episode names in the format 'SxxExx - Episode Name'.", (options) =>
+            var response = await openAIService.Chat.Get($"The following list of filenames are in the format of <Show Title><Separator><Season><Episodes><Separator><Optional Title>.<Extension>. I want them to be in the format \"{showName}.S<Season Number>E<Episode Number>.<PascalCase Title>.<Extension>. If the Title isn't in the filename, grab it from theTVDB, using the {showName} DVD Order tab.\r\n{fileNamesString}\r\nGive me back the list of updated filenames", (options) =>
             {
                 options.Model = "gpt-3.5-turbo";
                 options.MaxTokens = 1000;
                 options.Temperature = 0.7;
             });
+
+            if (response.IsSuccess)
+            {
+                var aiResponseText = response.Result!.Choices[0].Message.Content;
+                Program.Logger.LogDebug($"AI Response: {aiResponseText}");
+            }
+            else
+            {
+                Program.Logger.LogError(response.ErrorResponse?.Error?.Message);
+            }
+
+            
         }
 
 

--- a/RenameEpisodeFiles/Form1.Designer.cs
+++ b/RenameEpisodeFiles/Form1.Designer.cs
@@ -49,8 +49,8 @@
             label6 = new Label();
             button1 = new Button();
             ModeGroup = new GroupBox();
-            radioModeDefault = new RadioButton();
             radioModeAI = new RadioButton();
+            radioModeDefault = new RadioButton();
             ModeGroup.SuspendLayout();
             SuspendLayout();
             // 
@@ -131,9 +131,9 @@
             // 
             // btnRename
             // 
-            btnRename.Location = new Point(676, 404);
+            btnRename.Location = new Point(640, 404);
             btnRename.Name = "btnRename";
-            btnRename.Size = new Size(112, 34);
+            btnRename.Size = new Size(148, 34);
             btnRename.TabIndex = 6;
             btnRename.Text = "Rename Files";
             btnRename.UseVisualStyleBackColor = true;
@@ -237,6 +237,17 @@
             ModeGroup.TabIndex = 17;
             ModeGroup.TabStop = false;
             // 
+            // radioModeAI
+            // 
+            radioModeAI.AutoSize = true;
+            radioModeAI.Location = new Point(15, 46);
+            radioModeAI.Name = "radioModeAI";
+            radioModeAI.Size = new Size(106, 29);
+            radioModeAI.TabIndex = 1;
+            radioModeAI.Text = "AI Mode";
+            radioModeAI.UseVisualStyleBackColor = true;
+            radioModeAI.CheckedChanged += radioModeAI_CheckedChanged;
+            // 
             // radioModeDefault
             // 
             radioModeDefault.AutoSize = true;
@@ -248,16 +259,7 @@
             radioModeDefault.TabStop = true;
             radioModeDefault.Text = "Default Mode";
             radioModeDefault.UseVisualStyleBackColor = true;
-            // 
-            // radioModeAI
-            // 
-            radioModeAI.AutoSize = true;
-            radioModeAI.Location = new Point(15, 46);
-            radioModeAI.Name = "radioModeAI";
-            radioModeAI.Size = new Size(106, 29);
-            radioModeAI.TabIndex = 1;
-            radioModeAI.Text = "AI Mode";
-            radioModeAI.UseVisualStyleBackColor = true;
+            radioModeDefault.CheckedChanged += radioModeDefault_CheckedChanged;
             // 
             // Form1
             // 

--- a/RenameEpisodeFiles/Form1.Designer.cs
+++ b/RenameEpisodeFiles/Form1.Designer.cs
@@ -48,6 +48,10 @@
             txtCopyFilesTo = new TextBox();
             label6 = new Label();
             button1 = new Button();
+            ModeGroup = new GroupBox();
+            radioModeDefault = new RadioButton();
+            radioModeAI = new RadioButton();
+            ModeGroup.SuspendLayout();
             SuspendLayout();
             // 
             // folderBrowserDialog1
@@ -223,12 +227,45 @@
             button1.UseVisualStyleBackColor = true;
             button1.Click += button1_Click_1;
             // 
+            // ModeGroup
+            // 
+            ModeGroup.Controls.Add(radioModeAI);
+            ModeGroup.Controls.Add(radioModeDefault);
+            ModeGroup.Location = new Point(359, 41);
+            ModeGroup.Name = "ModeGroup";
+            ModeGroup.Size = new Size(315, 75);
+            ModeGroup.TabIndex = 17;
+            ModeGroup.TabStop = false;
+            // 
+            // radioModeDefault
+            // 
+            radioModeDefault.AutoSize = true;
+            radioModeDefault.Checked = true;
+            radioModeDefault.Location = new Point(15, 11);
+            radioModeDefault.Name = "radioModeDefault";
+            radioModeDefault.Size = new Size(146, 29);
+            radioModeDefault.TabIndex = 0;
+            radioModeDefault.TabStop = true;
+            radioModeDefault.Text = "Default Mode";
+            radioModeDefault.UseVisualStyleBackColor = true;
+            // 
+            // radioModeAI
+            // 
+            radioModeAI.AutoSize = true;
+            radioModeAI.Location = new Point(15, 46);
+            radioModeAI.Name = "radioModeAI";
+            radioModeAI.Size = new Size(106, 29);
+            radioModeAI.TabIndex = 1;
+            radioModeAI.Text = "AI Mode";
+            radioModeAI.UseVisualStyleBackColor = true;
+            // 
             // Form1
             // 
             AllowDrop = true;
             AutoScaleDimensions = new SizeF(10F, 25F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(800, 450);
+            Controls.Add(ModeGroup);
             Controls.Add(button1);
             Controls.Add(label6);
             Controls.Add(txtCopyFilesTo);
@@ -249,6 +286,8 @@
             Controls.Add(label1);
             Name = "Form1";
             Text = "Rename Episodes";
+            ModeGroup.ResumeLayout(false);
+            ModeGroup.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -275,5 +314,8 @@
         private TextBox txtCopyFilesTo;
         private Label label6;
         private Button button1;
+        private GroupBox ModeGroup;
+        private RadioButton radioModeDefault;
+        private RadioButton radioModeAI;
     }
 }

--- a/RenameEpisodeFiles/Form1.Designer.cs
+++ b/RenameEpisodeFiles/Form1.Designer.cs
@@ -51,6 +51,7 @@
             ModeGroup = new GroupBox();
             radioModeAI = new RadioButton();
             radioModeDefault = new RadioButton();
+            progressRename = new ProgressBar();
             ModeGroup.SuspendLayout();
             SuspendLayout();
             // 
@@ -137,7 +138,7 @@
             btnRename.TabIndex = 6;
             btnRename.Text = "Rename Files";
             btnRename.UseVisualStyleBackColor = true;
-            btnRename.Click += btnRename_Click;
+            btnRename.Click += btnRename_ClickAsync;
             // 
             // lblErr
             // 
@@ -261,12 +262,22 @@
             radioModeDefault.UseVisualStyleBackColor = true;
             radioModeDefault.CheckedChanged += radioModeDefault_CheckedChanged;
             // 
+            // progressRename
+            // 
+            progressRename.Location = new Point(403, 404);
+            progressRename.Name = "progressRename";
+            progressRename.Size = new Size(231, 34);
+            progressRename.Style = ProgressBarStyle.Marquee;
+            progressRename.TabIndex = 18;
+            progressRename.Visible = false;
+            // 
             // Form1
             // 
             AllowDrop = true;
             AutoScaleDimensions = new SizeF(10F, 25F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(800, 450);
+            Controls.Add(progressRename);
             Controls.Add(ModeGroup);
             Controls.Add(button1);
             Controls.Add(label6);
@@ -319,5 +330,6 @@
         private GroupBox ModeGroup;
         private RadioButton radioModeDefault;
         private RadioButton radioModeAI;
+        private ProgressBar progressRename;
     }
 }

--- a/RenameEpisodeFiles/Form1.Designer.cs
+++ b/RenameEpisodeFiles/Form1.Designer.cs
@@ -62,18 +62,20 @@
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new Point(122, 9);
+            label1.Location = new Point(85, 5);
+            label1.Margin = new Padding(2, 0, 2, 0);
             label1.Name = "label1";
-            label1.Size = new Size(101, 25);
+            label1.Size = new Size(67, 15);
             label1.TabIndex = 0;
             label1.Text = "Folder Path";
             // 
             // txtFolderPath
             // 
             txtFolderPath.AllowDrop = true;
-            txtFolderPath.Location = new Point(229, 6);
+            txtFolderPath.Location = new Point(160, 4);
+            txtFolderPath.Margin = new Padding(2);
             txtFolderPath.Name = "txtFolderPath";
-            txtFolderPath.Size = new Size(510, 31);
+            txtFolderPath.Size = new Size(358, 23);
             txtFolderPath.TabIndex = 1;
             txtFolderPath.DragDrop += txtFolderPath_DragDrop;
             txtFolderPath.DragEnter += txtFolderPath_DragEnter;
@@ -81,60 +83,67 @@
             // label2
             // 
             label2.AutoSize = true;
-            label2.Location = new Point(12, 91);
+            label2.Location = new Point(8, 55);
+            label2.Margin = new Padding(2, 0, 2, 0);
             label2.Name = "label2";
-            label2.Size = new Size(211, 25);
+            label2.Size = new Size(139, 15);
             label2.TabIndex = 2;
             label2.Text = "Starting Episode Number";
             // 
             // txtFirstEpisode
             // 
-            txtFirstEpisode.Location = new Point(229, 91);
+            txtFirstEpisode.Location = new Point(160, 55);
+            txtFirstEpisode.Margin = new Padding(2);
             txtFirstEpisode.Name = "txtFirstEpisode";
-            txtFirstEpisode.Size = new Size(65, 31);
+            txtFirstEpisode.Size = new Size(47, 23);
             txtFirstEpisode.TabIndex = 3;
             txtFirstEpisode.Text = "1";
             // 
             // label3
             // 
             label3.AutoSize = true;
-            label3.Location = new Point(83, 52);
+            label3.Location = new Point(58, 31);
+            label3.Margin = new Padding(2, 0, 2, 0);
             label3.Name = "label3";
-            label3.Size = new Size(139, 25);
+            label3.Size = new Size(91, 15);
             label3.TabIndex = 4;
             label3.Text = "Season Number";
             // 
             // txtSeasonNumber
             // 
-            txtSeasonNumber.Location = new Point(228, 49);
+            txtSeasonNumber.Location = new Point(160, 29);
+            txtSeasonNumber.Margin = new Padding(2);
             txtSeasonNumber.Name = "txtSeasonNumber";
-            txtSeasonNumber.Size = new Size(66, 31);
+            txtSeasonNumber.Size = new Size(47, 23);
             txtSeasonNumber.TabIndex = 2;
             // 
             // label4
             // 
             label4.AutoSize = true;
-            label4.Location = new Point(105, 134);
+            label4.Location = new Point(74, 85);
+            label4.Margin = new Padding(2, 0, 2, 0);
             label4.Name = "label4";
-            label4.Size = new Size(117, 25);
+            label4.Size = new Size(75, 15);
             label4.TabIndex = 6;
             label4.Text = "Episode Data";
             // 
             // txtEpisodeData
             // 
             txtEpisodeData.AllowDrop = true;
-            txtEpisodeData.Location = new Point(229, 131);
+            txtEpisodeData.Location = new Point(160, 82);
+            txtEpisodeData.Margin = new Padding(2);
             txtEpisodeData.Name = "txtEpisodeData";
-            txtEpisodeData.Size = new Size(510, 31);
+            txtEpisodeData.Size = new Size(358, 23);
             txtEpisodeData.TabIndex = 4;
             txtEpisodeData.DragDrop += txtEpisodeData_DragDrop;
             txtEpisodeData.DragEnter += txtEpisodeData_DragEnter;
             // 
             // btnRename
             // 
-            btnRename.Location = new Point(640, 404);
+            btnRename.Location = new Point(448, 234);
+            btnRename.Margin = new Padding(2);
             btnRename.Name = "btnRename";
-            btnRename.Size = new Size(148, 34);
+            btnRename.Size = new Size(104, 28);
             btnRename.TabIndex = 6;
             btnRename.Text = "Rename Files";
             btnRename.UseVisualStyleBackColor = true;
@@ -143,33 +152,37 @@
             // lblErr
             // 
             lblErr.AutoSize = true;
-            lblErr.Location = new Point(229, 409);
+            lblErr.Location = new Point(160, 241);
+            lblErr.Margin = new Padding(2, 0, 2, 0);
             lblErr.Name = "lblErr";
-            lblErr.Size = new Size(157, 25);
+            lblErr.Size = new Size(102, 15);
             lblErr.TabIndex = 9;
             lblErr.Text = "Enter Data to Start";
             // 
             // label5
             // 
             label5.AutoSize = true;
-            label5.Location = new Point(114, 181);
+            label5.Location = new Point(74, 112);
+            label5.Margin = new Padding(2, 0, 2, 0);
             label5.Name = "label5";
-            label5.Size = new Size(108, 25);
+            label5.Size = new Size(71, 15);
             label5.TabIndex = 10;
             label5.Text = "Show Name";
             // 
             // txtShowName
             // 
-            txtShowName.Location = new Point(229, 178);
+            txtShowName.Location = new Point(160, 109);
+            txtShowName.Margin = new Padding(2);
             txtShowName.Name = "txtShowName";
-            txtShowName.Size = new Size(510, 31);
+            txtShowName.Size = new Size(358, 23);
             txtShowName.TabIndex = 5;
             // 
             // btnCleanEpisodeData
             // 
-            btnCleanEpisodeData.Location = new Point(17, 404);
+            btnCleanEpisodeData.Location = new Point(12, 234);
+            btnCleanEpisodeData.Margin = new Padding(2);
             btnCleanEpisodeData.Name = "btnCleanEpisodeData";
-            btnCleanEpisodeData.Size = new Size(206, 34);
+            btnCleanEpisodeData.Size = new Size(144, 28);
             btnCleanEpisodeData.TabIndex = 11;
             btnCleanEpisodeData.Text = "Clean Episode Data";
             btnCleanEpisodeData.UseVisualStyleBackColor = true;
@@ -177,9 +190,10 @@
             // 
             // btnFindFolder
             // 
-            btnFindFolder.Location = new Point(745, 6);
+            btnFindFolder.Location = new Point(522, 4);
+            btnFindFolder.Margin = new Padding(2);
             btnFindFolder.Name = "btnFindFolder";
-            btnFindFolder.Size = new Size(43, 34);
+            btnFindFolder.Size = new Size(30, 23);
             btnFindFolder.TabIndex = 12;
             btnFindFolder.Text = "?";
             btnFindFolder.UseVisualStyleBackColor = true;
@@ -187,9 +201,10 @@
             // 
             // btnFindEpisodeData
             // 
-            btnFindEpisodeData.Location = new Point(745, 131);
+            btnFindEpisodeData.Location = new Point(522, 82);
+            btnFindEpisodeData.Margin = new Padding(2);
             btnFindEpisodeData.Name = "btnFindEpisodeData";
-            btnFindEpisodeData.Size = new Size(43, 34);
+            btnFindEpisodeData.Size = new Size(30, 23);
             btnFindEpisodeData.TabIndex = 13;
             btnFindEpisodeData.Text = "?";
             btnFindEpisodeData.UseVisualStyleBackColor = true;
@@ -202,9 +217,10 @@
             // txtCopyFilesTo
             // 
             txtCopyFilesTo.AllowDrop = true;
-            txtCopyFilesTo.Location = new Point(229, 224);
+            txtCopyFilesTo.Location = new Point(160, 136);
+            txtCopyFilesTo.Margin = new Padding(2);
             txtCopyFilesTo.Name = "txtCopyFilesTo";
-            txtCopyFilesTo.Size = new Size(510, 31);
+            txtCopyFilesTo.Size = new Size(358, 23);
             txtCopyFilesTo.TabIndex = 14;
             txtCopyFilesTo.DragDrop += txtCopyFilesTo_DragDrop;
             txtCopyFilesTo.DragEnter += txtCopyFilesTo_DragEnter;
@@ -212,17 +228,19 @@
             // label6
             // 
             label6.AutoSize = true;
-            label6.Location = new Point(105, 227);
+            label6.Location = new Point(74, 139);
+            label6.Margin = new Padding(2, 0, 2, 0);
             label6.Name = "label6";
-            label6.Size = new Size(116, 25);
+            label6.Size = new Size(77, 15);
             label6.TabIndex = 15;
             label6.Text = "Copy Files To";
             // 
             // button1
             // 
-            button1.Location = new Point(745, 224);
+            button1.Location = new Point(522, 136);
+            button1.Margin = new Padding(2);
             button1.Name = "button1";
-            button1.Size = new Size(43, 34);
+            button1.Size = new Size(30, 23);
             button1.TabIndex = 16;
             button1.Text = "?";
             button1.UseVisualStyleBackColor = true;
@@ -232,18 +250,22 @@
             // 
             ModeGroup.Controls.Add(radioModeAI);
             ModeGroup.Controls.Add(radioModeDefault);
-            ModeGroup.Location = new Point(359, 41);
+            ModeGroup.Location = new Point(337, 31);
+            ModeGroup.Margin = new Padding(2);
             ModeGroup.Name = "ModeGroup";
-            ModeGroup.Size = new Size(315, 75);
+            ModeGroup.Padding = new Padding(2);
+            ModeGroup.Size = new Size(181, 47);
             ModeGroup.TabIndex = 17;
             ModeGroup.TabStop = false;
+            ModeGroup.Visible = false;
             // 
             // radioModeAI
             // 
             radioModeAI.AutoSize = true;
-            radioModeAI.Location = new Point(15, 46);
+            radioModeAI.Location = new Point(105, 20);
+            radioModeAI.Margin = new Padding(2);
             radioModeAI.Name = "radioModeAI";
-            radioModeAI.Size = new Size(106, 29);
+            radioModeAI.Size = new Size(70, 19);
             radioModeAI.TabIndex = 1;
             radioModeAI.Text = "AI Mode";
             radioModeAI.UseVisualStyleBackColor = true;
@@ -253,9 +275,10 @@
             // 
             radioModeDefault.AutoSize = true;
             radioModeDefault.Checked = true;
-            radioModeDefault.Location = new Point(15, 11);
+            radioModeDefault.Location = new Point(4, 20);
+            radioModeDefault.Margin = new Padding(2);
             radioModeDefault.Name = "radioModeDefault";
-            radioModeDefault.Size = new Size(146, 29);
+            radioModeDefault.Size = new Size(97, 19);
             radioModeDefault.TabIndex = 0;
             radioModeDefault.TabStop = true;
             radioModeDefault.Text = "Default Mode";
@@ -264,9 +287,10 @@
             // 
             // progressRename
             // 
-            progressRename.Location = new Point(403, 404);
+            progressRename.Location = new Point(282, 239);
+            progressRename.Margin = new Padding(2);
             progressRename.Name = "progressRename";
-            progressRename.Size = new Size(231, 34);
+            progressRename.Size = new Size(162, 20);
             progressRename.Style = ProgressBarStyle.Marquee;
             progressRename.TabIndex = 18;
             progressRename.Visible = false;
@@ -274,9 +298,9 @@
             // Form1
             // 
             AllowDrop = true;
-            AutoScaleDimensions = new SizeF(10F, 25F);
+            AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(800, 450);
+            ClientSize = new Size(560, 270);
             Controls.Add(progressRename);
             Controls.Add(ModeGroup);
             Controls.Add(button1);
@@ -297,6 +321,7 @@
             Controls.Add(label2);
             Controls.Add(txtFolderPath);
             Controls.Add(label1);
+            Margin = new Padding(2);
             Name = "Form1";
             Text = "Rename Episodes";
             ModeGroup.ResumeLayout(false);

--- a/RenameEpisodeFiles/Form1.cs
+++ b/RenameEpisodeFiles/Form1.cs
@@ -5,6 +5,14 @@ namespace RenameEpisodeFiles
 {
     public partial class Form1 : Form
     {
+        private enum RenameMode
+        {
+            Default,
+            AI
+        }
+
+        private RenameMode _renameMode = RenameMode.Default;
+
         public Form1()
         {
             InitializeComponent();
@@ -13,65 +21,86 @@ namespace RenameEpisodeFiles
         private void btnRename_Click(object sender, EventArgs e)
         {
 
-            #region basic validation
-            lblErr.Text = "";
-
-            string folderPath = txtFolderPath.Text;
-            if (string.IsNullOrEmpty(folderPath))
+            if (_renameMode == RenameMode.Default)
             {
-                lblErr.Text = "Fix folder path";
-                return;
-            }
+                #region basic validation
+                lblErr.Text = "";
 
-            if (!int.TryParse(txtFirstEpisode.Text, out int episodeNumber))
-            {
-                lblErr.Text = "Fix episode number";
-                return;
-            }
-
-            if (!int.TryParse(txtSeasonNumber.Text, out int seasonNumber))
-            {
-                lblErr.Text = "Fix season number";
-                return;
-            }
-
-            string dataPath = txtEpisodeData.Text;
-            if (string.IsNullOrEmpty(dataPath))
-            {
-                lblErr.Text = "Fix data path";
-                return;
-            }
-
-            string showName = txtShowName.Text;
-            if (string.IsNullOrEmpty(showName))
-            {
-                lblErr.Text = "Fix show Name";
-                return;
-            }
-            #endregion
-
-            int lastEpisode = FileRenamer.RenameEpisodes(folderPath, showName, seasonNumber, episodeNumber, dataPath);
-
-            // copy the files over to the destination after the rename
-            // but only if the field is populated
-            if (!string.IsNullOrEmpty(txtCopyFilesTo.Text))
-            {
-                string destinationDirectory = txtCopyFilesTo.Text;
-                string sourceDirectory = txtFolderPath.Text;
-
-                Directory.CreateDirectory(destinationDirectory); // Ensure destination exists
-
-                foreach (var filePath in Directory.GetFiles(sourceDirectory))
+                string folderPath = txtFolderPath.Text;
+                if (string.IsNullOrEmpty(folderPath))
                 {
-                    string fileName = Path.GetFileName(filePath);
-                    string destPath = Path.Combine(destinationDirectory, fileName);
-                    File.Copy(filePath, destPath, overwrite: true);
+                    lblErr.Text = "Fix folder path";
+                    return;
                 }
-            }
 
-            // update the episode number so next path can be run easier
-            txtFirstEpisode.Text = (lastEpisode + 1).ToString();
-            txtFolderPath.Text = "";
+                if (!int.TryParse(txtFirstEpisode.Text, out int episodeNumber))
+                {
+                    lblErr.Text = "Fix episode number";
+                    return;
+                }
+
+                if (!int.TryParse(txtSeasonNumber.Text, out int seasonNumber))
+                {
+                    lblErr.Text = "Fix season number";
+                    return;
+                }
+
+                string dataPath = txtEpisodeData.Text;
+                if (string.IsNullOrEmpty(dataPath))
+                {
+                    lblErr.Text = "Fix data path";
+                    return;
+                }
+
+                string showName = txtShowName.Text;
+                if (string.IsNullOrEmpty(showName))
+                {
+                    lblErr.Text = "Fix show Name";
+                    return;
+                }
+                #endregion
+
+                int lastEpisode = FileRenamer.RenameEpisodes(folderPath, showName, seasonNumber, episodeNumber, dataPath);
+
+                // copy the files over to the destination after the rename
+                // but only if the field is populated
+                if (!string.IsNullOrEmpty(txtCopyFilesTo.Text))
+                {
+                    string destinationDirectory = txtCopyFilesTo.Text;
+                    string sourceDirectory = txtFolderPath.Text;
+
+                    Directory.CreateDirectory(destinationDirectory); // Ensure destination exists
+
+                    foreach (var filePath in Directory.GetFiles(sourceDirectory))
+                    {
+                        string fileName = Path.GetFileName(filePath);
+                        string destPath = Path.Combine(destinationDirectory, fileName);
+                        File.Copy(filePath, destPath, overwrite: true);
+                    }
+                }
+
+                // update the episode number so next path can be run easier
+                txtFirstEpisode.Text = (lastEpisode + 1).ToString();
+                txtFolderPath.Text = ""; 
+            }
+            else if (_renameMode == RenameMode.AI)
+            {
+                lblErr.Text = "";
+                string folderPath = txtFolderPath.Text;
+                if (string.IsNullOrEmpty(folderPath))
+                {
+                    lblErr.Text = "Fix folder path";
+                    return;
+                }
+                string showName = txtShowName.Text;
+                if (string.IsNullOrEmpty(showName))
+                {
+                    lblErr.Text = "Fix show Name";
+                    return;
+                }
+                // Call the AI renaming method
+                FileRenamer.RenameEpisodesWithAI(folderPath, showName);
+            }
 
         }
 
@@ -189,6 +218,34 @@ namespace RenameEpisodeFiles
                 {
                     txtCopyFilesTo.Text = paths[0]; // This could be a file or a folder path
                 }
+            }
+        }
+
+        private void radioModeAI_CheckedChanged(object sender, EventArgs e)
+        {
+            if (radioModeAI.Checked)
+            {
+                _renameMode = RenameMode.AI;
+                btnRename.Text = "Rename with AI";
+            }
+            else
+            {
+                _renameMode = RenameMode.Default;
+                btnRename.Text = "Rename Files";
+            }
+        }
+
+        private void radioModeDefault_CheckedChanged(object sender, EventArgs e)
+        {
+            if (radioModeDefault.Checked)
+            {
+                _renameMode = RenameMode.Default;
+                btnRename.Text = "Rename Files";
+            }
+            else
+            {
+                _renameMode = RenameMode.AI;
+                btnRename.Text = "Rename with AI";
             }
         }
     }

--- a/RenameEpisodeFiles/Form1.cs
+++ b/RenameEpisodeFiles/Form1.cs
@@ -18,7 +18,7 @@ namespace RenameEpisodeFiles
             InitializeComponent();
         }
 
-        private void btnRename_Click(object sender, EventArgs e)
+        private async void btnRename_ClickAsync(object sender, EventArgs e)
         {
 
             if (_renameMode == RenameMode.Default)
@@ -98,8 +98,13 @@ namespace RenameEpisodeFiles
                     lblErr.Text = "Fix show Name";
                     return;
                 }
+
+                btnRename.Enabled = false; // Disable button to prevent multiple clicks
+                progressRename.Visible = true; // Show progress bar
                 // Call the AI renaming method
-                FileRenamer.RenameEpisodesWithAI(folderPath, showName);
+                await FileRenamer.RenameEpisodesWithAI(folderPath, showName);
+                progressRename.Visible = false; // Hide progress bar after operation
+                btnRename.Enabled = true; // Re-enable button after operation;
             }
 
         }

--- a/RenameEpisodeFiles/Form1.cs
+++ b/RenameEpisodeFiles/Form1.cs
@@ -16,6 +16,11 @@ namespace RenameEpisodeFiles
         public Form1()
         {
             InitializeComponent();
+
+            if(Program.OpenAIService != null)
+            {
+                ModeGroup.Visible = true;
+            }
         }
 
         private async void btnRename_ClickAsync(object sender, EventArgs e)

--- a/RenameEpisodeFiles/Form1.resx
+++ b/RenameEpisodeFiles/Form1.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/RenameEpisodeFiles/Program.cs
+++ b/RenameEpisodeFiles/Program.cs
@@ -1,13 +1,36 @@
+using System.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenAI.Net;
+
 namespace RenameEpisodeFiles
 {
     internal static class Program
     {
+        public static IConfiguration Configuration { get; private set; }
+        public static IOpenAIService OpenAIService { get; private set; }
+
         /// <summary>
         ///  The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
+            // Build configuration to load secrets.json from the application directory
+            Configuration = new ConfigurationBuilder()
+                .SetBasePath(AppContext.BaseDirectory)
+                .AddJsonFile("secrets.json", optional: false, reloadOnChange: true)
+                .Build();
+
+            // Configure OpenAI service
+            var services = new ServiceCollection();
+            services.AddOpenAIServices(options =>
+            {
+                options.ApiKey = Configuration["OpenAI:ApiKey"];
+            });
+            var provider = services.BuildServiceProvider();
+            OpenAIService = provider.GetRequiredService<IOpenAIService>();
+
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.
             ApplicationConfiguration.Initialize();

--- a/RenameEpisodeFiles/Program.cs
+++ b/RenameEpisodeFiles/Program.cs
@@ -1,6 +1,9 @@
 using System.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Debug;
+using Microsoft.Extensions.Logging.Console;
 using OpenAI.Net;
 
 namespace RenameEpisodeFiles
@@ -9,6 +12,8 @@ namespace RenameEpisodeFiles
     {
         public static IConfiguration Configuration { get; private set; }
         public static IOpenAIService OpenAIService { get; private set; }
+        public static ILoggerFactory LoggerFactory { get; private set; }
+        public static ILogger Logger { get; private set; }
 
         /// <summary>
         ///  The main entry point for the application.
@@ -30,6 +35,16 @@ namespace RenameEpisodeFiles
             });
             var provider = services.BuildServiceProvider();
             OpenAIService = provider.GetRequiredService<IOpenAIService>();
+
+            // Configure logging
+            LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
+            {
+                builder
+                    .SetMinimumLevel(LogLevel.Debug) // Ensure Debug level is enabled
+                    .AddDebug()    // Logs to Output window in Visual Studio
+                    .AddConsole();
+            });
+            Logger = LoggerFactory.CreateLogger("App");
 
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.

--- a/RenameEpisodeFiles/Program.cs
+++ b/RenameEpisodeFiles/Program.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Debug;
 using Microsoft.Extensions.Logging.Console;
 using OpenAI.Net;
+using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace RenameEpisodeFiles
 {
@@ -13,7 +15,7 @@ namespace RenameEpisodeFiles
         public static IConfiguration Configuration { get; private set; } = null!;
         public static IOpenAIService? OpenAIService { get; private set; }
         public static ILoggerFactory LoggerFactory { get; private set; } = null!;
-        public static ILogger Logger { get; private set; } = null!;
+        public static Microsoft.Extensions.Logging.ILogger Logger { get; private set; } = null!;
 
         /// <summary>
         ///  The main entry point for the application.
@@ -38,14 +40,15 @@ namespace RenameEpisodeFiles
                 OpenAIService = provider.GetRequiredService<IOpenAIService>();
             }
 
-            // Configure logging
-            LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
-            {
-                builder
-                    .SetMinimumLevel(LogLevel.Debug) // Ensure Debug level is enabled
-                    .AddDebug()    // Logs to Output window in Visual Studio
-                    .AddConsole();
-            });
+            // Configure Serilog for file logging
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File("app.log", rollingInterval: RollingInterval.Day)
+                .WriteTo.Console()
+                .CreateLogger();
+
+            // Integrate Serilog with Microsoft.Extensions.Logging
+            LoggerFactory = new SerilogLoggerFactory(Log.Logger, dispose: false);
             Logger = LoggerFactory.CreateLogger("App");
 
             // To customize application configuration such as set high DPI settings or default font,

--- a/RenameEpisodeFiles/RenameEpisodeFiles.csproj
+++ b/RenameEpisodeFiles/RenameEpisodeFiles.csproj
@@ -16,6 +16,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
     <PackageReference Include="OpenAI.Net.Client" Version="1.0.21" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RenameEpisodeFiles/RenameEpisodeFiles.csproj
+++ b/RenameEpisodeFiles/RenameEpisodeFiles.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Version>0.2.0.0</Version>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RenameEpisodeFiles/RenameEpisodeFiles.csproj
+++ b/RenameEpisodeFiles/RenameEpisodeFiles.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
     <PackageReference Include="OpenAI.Net.Client" Version="1.0.21" />
   </ItemGroup>
 

--- a/RenameEpisodeFiles/RenameEpisodeFiles.csproj
+++ b/RenameEpisodeFiles/RenameEpisodeFiles.csproj
@@ -8,4 +8,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="OpenAI.Net.Client" Version="1.0.21" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="secrets.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Scripts/CreateEmptyFiles.ps1
+++ b/Scripts/CreateEmptyFiles.ps1
@@ -1,0 +1,54 @@
+# PowerShell script to create empty files with specified filenames in the current directory
+
+$filenames = @"
+Star Trek - Deep Space Nine.S03E09.Defiant.mkv
+Star Trek - Deep Space Nine.S03E10.Fascination.mkv
+Star Trek_ Deep Space Nine - s04e01 - The Way Of the Warrior.mp4
+Star Trek_ Deep Space Nine - s04e03 - The Visitor.mp4
+Star Trek_ Deep Space Nine - s04e04 - Hippocratic Oath.mp4
+Star Trek_ Deep Space Nine - s04e09 - The Sword Of Kahless.mp4
+Star Trek_ Deep Space Nine - s04e10 - Our Man Bashir.mp4
+Star Trek_ Deep Space Nine - s04e11 - Homefront.mp4
+Star Trek_ Deep Space Nine - s04e12 - Paradise Lost.mp4
+Startrekds9.s03e11.mkv
+Startrekds9.s03e12.mkv
+Startrekds9.s03e13.mkv
+Startrekds9.s03e14.mkv
+Startrekds9.s03e15.mkv
+Startrekds9.s03e16.mkv
+Startrekds9.s03e17.mkv
+Startrekds9.s03e18.mkv
+Startrekds9.s03e19.mkv
+Startrekds9.s03e20.mkv
+Startrekds9.s03e25.mkv
+Startrekds9.s03e26.mkv
+Startrekds9.s04e05.mkv
+Startrekds9.s04e06.mkv
+Startrekds9.s04e07.mkv
+Startrekds9.s04e08.mkv
+Startrekds9.s04e13.mkv
+Startrekds9.s04e14.mkv
+Startrekds9.s04e15.mkv
+Startrekds9.s04e16.mkv
+Startrekds9.s04e17.mkv
+Startrekds9.s04e18.mkv
+Startrekds9.s04e19.mkv
+Startrekds9.s04e20.mkv
+Startrekds9.s04e21.mkv
+Startrekds9.s04e22.mkv
+Startrekds9.s04e23.mkv
+Startrekds9.s04e24.mkv
+Startrekds9.s04e25.mkv
+Startrekds9.s04e26.mkv
+"@ -split "`n"
+
+$subfolder = "TestFiles"
+New-Item -ItemType Directory -Path $subfolder -Force | Out-Null
+
+foreach ($filename in $filenames) {
+    $trimmed = $filename.Trim()
+    if ($trimmed) {
+        $filepath = Join-Path $subfolder $trimmed
+        New-Item -ItemType File -Path $filepath -Force | Out-Null
+    }
+}

--- a/Scripts/CreateEmptyFiles.ps1
+++ b/Scripts/CreateEmptyFiles.ps1
@@ -45,6 +45,8 @@ Startrekds9.s04e26.mkv
 $subfolder = "TestFiles"
 New-Item -ItemType Directory -Path $subfolder -Force | Out-Null
 
+Get-ChildItem $subFolder -File | Remove-Item | Out-Null
+
 foreach ($filename in $filenames) {
     $trimmed = $filename.Trim()
     if ($trimmed) {


### PR DESCRIPTION
# Context
## Goal
- Add the Ability to use an AI call (OpenAI in this case) to get the Episode Title from the Season and Episode number given a Show Name and use that when renaming
## Additional Changes
1. Added Logging for the AI Rename, both to the Console and to a File
2. Added a Mode Toggle for Default vs. AI mode, only shown when a secrets.json with OpenAI Key exists
3. Added a Progress Bar during AI Rename
4. Tweaked Sizing and Alignment of Controls
5. Added Test File Creation Script to make it easier to generate empty files to test with
6. Added Versioning to the Application as well

# Screenshots
1. AI Mode Enabled
<img width="572" height="310" alt="image" src="https://github.com/user-attachments/assets/086856c3-fb20-427e-8e3a-7d6732f5a544" />
